### PR TITLE
Don't ignore params in getActiveOrders()

### DIFF
--- a/lib/private-methods.js
+++ b/lib/private-methods.js
@@ -25,6 +25,21 @@ class PrivateMethods {
             type: params.type ? params.type : 'ALL',
             owner: params.owner ? params.owner : 'ALL',
         };
+        if(params.from !== undefined) {
+            data.from = params.from;
+        }
+        if(params.from_id !== undefined) {
+            data.from_id = params.from_id;
+        }
+        if(params.end_id !== undefined) {
+            data.end_id = params.end_id;
+        }
+        if(params.since !== undefined) {
+            data.since = params.since;
+        }
+        if(params.end !== undefined) {
+            data.end = params.end;
+        }
         data.order = !params.since || !params.end ? 'ASC' : 'DESC';
         data.method = 'ActiveOrders';
         this.request(data, function (res) {


### PR DESCRIPTION
Few parameters in getActiveOrders() are not passed to HTTP API. This pull request fixes it.